### PR TITLE
Fix DFRobot/DFRobot_INA219#2

### DIFF
--- a/Python/RespberryPi/DFRobot_INA219.py
+++ b/Python/RespberryPi/DFRobot_INA219.py
@@ -115,9 +115,9 @@ class INA219:
     def set_bus_ADC(self, bits, sample):
         conf = 0
         value = 0
-        if(bits < adc_bits_12 and sample > adc_sample_1):
+        if(bits < self.adc_bits_12 and sample > self.adc_sample_1):
             return
-        if(bits < adc_bits_12):
+        if(bits < self.adc_bits_12):
             value = bits
         else:
             value = 0x80 | sample
@@ -129,9 +129,9 @@ class INA219:
     def set_shunt_ADC(self, bits, sample):
         conf = 0
         value = 0
-        if(bits < adc_bits_12 and sample > adc_sample_1):
+        if(bits < self.adc_bits_12 and sample > self.adc_sample_1):
             return
-        if(bits < adc_bits_12):
+        if(bits < self.adc_bits_12):
             value = bits
         else:
             value = 0x80 | sample


### PR DESCRIPTION
Fixed the syntax of instance variables `add_bits_12` and `adc_sample_1` inside methods `set_bus_ADC` and `set_shunt_ADC` that caused the NameError.