### PR TITLE
Added possibility to change I2C speed

### DIFF
--- a/DFRobot_INA219.cpp
+++ b/DFRobot_INA219.cpp
@@ -137,6 +137,7 @@ void DFRobot_INA219_IIC::writeReg(uint8_t reg, uint8_t *pBuf, uint16_t len)
 {
     lastOperateStatus = eIna219_WriteRegError;
     _pWire->begin();
+    _pWire->setClock(_speed);
     _pWire->beginTransmission(_addr);
     _pWire->write(reg);
     for(uint16_t i = 0; i < len; i ++)
@@ -149,6 +150,7 @@ void DFRobot_INA219_IIC::readReg(uint8_t reg, uint8_t *pBuf, uint16_t len)
 {
     lastOperateStatus = eIna219_ReadRegError;
     _pWire->begin();
+    _pWire->setClock(_speed);
     _pWire->beginTransmission(_addr);
     _pWire->write(reg);
     if(_pWire->endTransmission() != 0)

--- a/DFRobot_INA219.h
+++ b/DFRobot_INA219.h
@@ -272,14 +272,15 @@ public:
      * @n INA219_I2C_ADDRESS3  0x44   A0 = 0  A1 = 1
      * @n INA219_I2C_ADDRESS4  0x45   A0 = 1  A1 = 1
      */
-    DFRobot_INA219_IIC(TwoWire *pWire, uint8_t i2caddr) : DFRobot_INA219() { _pWire = pWire; _addr = i2caddr; }
+    DFRobot_INA219_IIC(uint8_t i2caddr, TwoWire *pWire = &Wire, uint32_t i2cspeed = 100000UL) : DFRobot_INA219() { _addr = i2caddr; _pWire = pWire; _speed = i2cspeed; }
 
 protected:
-    void    writeReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
-    void    readReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
+    void writeReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
+    void readReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
     bool scan();
-    uint8_t   _addr;
-    TwoWire   *_pWire;
+    uint8_t _addr;
+    uint32_t _speed;
+    TwoWire *_pWire;
 };
 
 #endif


### PR DESCRIPTION
Every data transmission between MCU and sensor is started with clearing buffers using begin() method, but this resets previously set up I2C clock speed. My modification allows user to override default I2C clock speed during sensor inicialization to custom value if needed.