### PR TITLE
add & modify begin() method to use defined Wire

### DIFF
--- a/DFRobot_INA219.cpp
+++ b/DFRobot_INA219.cpp
@@ -191,3 +191,24 @@ bool DFRobot_INA219_IIC::scan()
     }
     return false;
 }
+
+bool DFRobot_INA219_IIC::begin()
+{
+    lastOperateStatus = eIna219_InitError;
+    _pWire->begin();
+    if (scan() == true)
+    {
+        setBRNG(eIna219BusVolRange_32V);
+        setPGA(eIna219PGABits_8);
+        setBADC(eIna219AdcBits_12, eIna219AdcSample_8);
+        setSADC(eIna219AdcBits_12, eIna219AdcSample_8);
+        setMode(eIna219SAndBVolCon);
+        calValue = 4096;
+        writeInaReg(INA219_REG_CALIBRATION, calValue);
+        lastOperateStatus = eIna219_ok;
+        return true;
+    }
+    else{
+        return false;
+    }
+}

--- a/DFRobot_INA219.h
+++ b/DFRobot_INA219.h
@@ -273,7 +273,7 @@ public:
      * @n INA219_I2C_ADDRESS4  0x45   A0 = 1  A1 = 1
      */
     DFRobot_INA219_IIC(TwoWire *pWire, uint8_t i2caddr) : DFRobot_INA219() { _pWire = pWire; _addr = i2caddr; }
-
+    bool begin();
 protected:
     void    writeReg(uint8_t reg, uint8_t *pBuf, uint16_t len);
     void    readReg(uint8_t reg, uint8_t *pBuf, uint16_t len);


### PR DESCRIPTION
I found an error during reading the current data from DFRobot_INA219. It was caused by the Wire object that is used to access method begin() is not same as the object of Wire that is defined so the setting is not completed and returns failed. I tried to create a begin() method for DFRobot_INA219_IIC class to use the pointed or defined Wire object.